### PR TITLE
Fix bug: ImportError

### DIFF
--- a/submarine/submarine.py
+++ b/submarine/submarine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from parser import parser
+from submarine.parser import parser
 
 # Usage
 usage = """


### PR DESCRIPTION
Fix the following error:
`Traceback (most recent call last):
  File "d:\python34\lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "d:\python34\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "D:\Python34\Scripts\submarine.exe\__main__.py", line 5, in <module>
  File "d:\python34\lib\site-packages\submarine\submarine.py", line 4, in <module>
    from parser import parser
ImportError: cannot import name 'parser'`
