### PR TITLE
Revert "Fix bug: ImportError"

### DIFF
--- a/submarine/submarine.py
+++ b/submarine/submarine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from submarine.parser import parser
+from parser import parser
 
 # Usage
 usage = """


### PR DESCRIPTION
Reverts tntcrowd/submarine#3

The error only occurs in Windows environment and the fix breaks the program in Unix-like environments.